### PR TITLE
213 buffer laea geom near antimeridian

### DIFF
--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1875,9 +1875,8 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
         south_dist = transform(_geom, toSRS=south_srs).Distance(
             point(0, 0, srs=south_srs)
         )
-        assert min([north_dist, south_dist]) > buffer_mtrs, (
-            f"buffered geometry would intersect with North or South Pole."
-        )
+        if min([north_dist, south_dist]) <= buffer_mtrs: 
+            raise GeoKitGeomError(f"buffered geometry would intersect with North or South Pole.")
 
         # convert geom to applyBufferInSRS
         _geom = transform(_geom, toSRS=applyBufferInSRS)

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1853,7 +1853,7 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
     if not applyBufferInSRS is False:
         # generate own geom-centered LAEA or load SRS
         if isinstance(applyBufferInSRS, str) and applyBufferInSRS.upper() == "LAEA":
-            applyBufferInSRS = SRS.centeredLAEA(geom=geom)
+            applyBufferInSRS = SRS.centeredLAEA(geom=_geom)
         else:
             try:
                 applyBufferInSRS = SRS.loadSRS(applyBufferInSRS)
@@ -1866,13 +1866,13 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
         north_srs = SRS.loadSRS(
             "+proj=aeqd +lat_0=90 +lon_0=0 +datum=WGS84 +units=m +no_defs"
         )
-        north_dist = transform(geom, toSRS=north_srs).Distance(
+        north_dist = transform(_geom, toSRS=north_srs).Distance(
             point(0, 0, srs=north_srs)
         )
         south_srs = SRS.loadSRS(
             "+proj=aeqd +lat_0=-90 +lon_0=0 +datum=WGS84 +units=m +no_defs"
         )
-        south_dist = transform(geom, toSRS=south_srs).Distance(
+        south_dist = transform(_geom, toSRS=south_srs).Distance(
             point(0, 0, srs=south_srs)
         )
         assert min([north_dist, south_dist]) > buffer_mtrs, (
@@ -1880,7 +1880,7 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
         )
 
         # convert geom to applyBufferInSRS
-        _geom = transform(geom, toSRS=applyBufferInSRS)
+        _geom = transform(_geom, toSRS=applyBufferInSRS)
 
     # apply buffer
     _geom_buf = _geom.Buffer(buffer)

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -826,6 +826,9 @@ def transform(
     # make sure geoms is a list
     if fromSRS is None:
         fromSRS = geoms[0].GetSpatialReference()
+        assert all([g.GetSpatialReference().IsSame(fromSRS) for g in geoms]), (
+            f"geoms have different SRS."
+        )
         if fromSRS is None:
             raise GeoKitGeomError("Could not determine fromSRS from geometry")
 

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1897,7 +1897,7 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
 
     # now retransform to original srs if needed
     if not applyBufferInSRS is False:
-        _geom_buf = transform(_geom_buf, toSRS=_srs)
+        _geom_buf = transform(_geom_buf, toSRS=_srs, revert360degProj=True)
 
     # now split if needed
     if not (split is None or isinstance(split, str) and split.upper() == "NONE"):

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1575,6 +1575,7 @@ def shift(geom, lonShift=0, latShift=0):
     """
     if not isinstance(geom, ogr.Geometry):
         raise TypeError(f"geom must be of type osgeo.ogr.Geometry")
+    geom = geom.Clone()  # do not modify input geom
     # first get srs of input geom
     _srs = geom.GetSpatialReference()
     # get the dimension of the geometry

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1837,10 +1837,10 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
         Allows to specify an EPSG integer code or an osgeo.osr.SpatialReference
         instance to define the SRS in which the buffer will be applied, then in
         the unit of the specified EPSG. If e.g. 6933 is given, the buffer will
-        be applied in meters in a metric system. By default False, i.e. the
+        be applied in meters in a metric system. Passing "laea" (case-insensitive)
+        will generate a geometry-centered, metric Lambert Azimuthal Equal Area 
+        system in which the buffer will be applied. By default False, i.e. the
         original SRS of the geom will be used.
-        NOTE: 'Lambert_Azimuthal_Equal_Area' or 'Lambert_Conformal_Conic_2SP'
-        projections are not allowed here, use e.g. EPSG:6933 as global metric SRS. #TODO LAEA is allowed now as str
     split : str, optional
         'shift' : shift areas that exceed the antimeridian line to the other end (default)
         'clip' : remove/clip polygon parts that exceed the antimeridian

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -763,7 +763,9 @@ def polygonizeMask(mask, bounds=None, srs=None, flat=True, shrink=True):
 # geometry transformer
 
 
-def transform(geoms, toSRS="europe_m", fromSRS=None, segment=None):
+def transform(
+    geoms, toSRS="europe_m", fromSRS=None, revert360degProj=False, segment=None
+):
     """Transform a geometry, or a list of geometries, from one SRS to another
 
     Parameters:
@@ -780,6 +782,13 @@ def transform(geoms, toSRS="europe_m", fromSRS=None, segment=None):
         The srs of the input geometries
           * Only needed if an SRS cannot be inferred from the geometry inputs or
             is, for whatever reason, the geometry's SRS is wrong
+
+    revert360degProj : bool; optional
+        If True, will revert the 360° shift that is applied by PROJ to points
+        beyond the antimeridian when transforming to EPSG:4326 to avoid invalid,
+        distorted geometries when points are only partially shifted. Will then
+        devliver a geometry that may partially be outside the -180° to 180°
+        longitude range. By default False.
 
     segment : float; optional
         An optional segmentation length to apply to the input geometries BEFORE
@@ -835,6 +844,59 @@ def transform(geoms, toSRS="europe_m", fromSRS=None, segment=None):
     r = [g.Transform(trx) for g in geoms]
     if sum(r) > 0:  # check fro errors
         raise GeoKitGeomError("Errors in geometry transformations")
+
+    if revert360degProj and toSRS.IsSame(SRS.loadSRS(4326)):
+
+        def _revert_antimeridian_proj(geom, max_width=180):
+            """Shift back points across the antimeridian to undo the effect of the PROJ function."""
+
+            def _shift_points(g):
+                """Shifts points back by +/-360° if PROJ shifted them due to the antimeridian"""
+                prev_x, _, _ = g.GetPoint(0)
+                for j in range(1, g.GetPointCount()):
+                    x, y, z = g.GetPoint(j)
+                    dx = x - prev_x
+                    if dx > max_width:
+                        x -= 360
+                    elif dx < -max_width:
+                        x += 360
+                    g.SetPoint(j, x, y, z)
+                    prev_x = x
+                return geom
+
+            # apply at different levels (directly to lines, indirectly to rings per polygon or recursively to multi-polygons/lines)
+            geom_type = geom.GetGeometryType()
+            if geom_type in (ogr.wkbPolygon, ogr.wkbPolygon25D):
+                for i in range(geom.GetGeometryCount()):
+                    _shift_points(geom.GetGeometryRef(i))
+            elif geom_type in (
+                ogr.wkbMultiPolygon,
+                ogr.wkbMultiPolygon25D,
+                ogr.wkbMultiLineString,
+                ogr.wkbMultiLineString25D,
+            ):
+                for i in range(geom.GetGeometryCount()):
+                    _revert_antimeridian_proj(geom.GetGeometryRef(i), max_width)
+            elif geom_type in (ogr.wkbLineString, ogr.wkbLineString25D):
+                _shift_points(geom)
+            # points are returned unchanged since here the projection across the antimeridian is desired
+            return geom
+
+        # polygons or lines crossing the antimeridian may have been distorted by PROJ operation
+        geoms = [_revert_antimeridian_proj(geom=g) for g in geoms]
+
+    # make sure all geoms are valid
+    try:
+        assert all(
+            [g.IsValid() for g in geoms]
+        )  # no msg, fall back to except only if needed to save time
+    except:
+        geoms = [
+            g.Buffer(0) for g in geoms
+        ]  # trick to reset boundary of unnecessarily invalid geoms
+        assert all([g.IsValid() for g in geoms]), (
+            f"Some geometries are invalid after transformation"
+        )
 
     # Done!
     if returnSingle:

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1946,7 +1946,7 @@ def fixOutOfBoundsGeoms(geom, how="shift"):
             center_lon = (env[0] + env[1]) / 2  # x value of center axis of whole geom
 
             def fold_polygon(polygon):
-                """Function that folds a polygon geometrie ofer 90° lat line"""
+                """Function that folds a polygon geometrie over 90° lat line"""
 
                 def _fold_ring(ring):
                     """core function for every linear ring"""

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1838,7 +1838,7 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
         instance to define the SRS in which the buffer will be applied, then in
         the unit of the specified EPSG. If e.g. 6933 is given, the buffer will
         be applied in meters in a metric system. Passing "laea" (case-insensitive)
-        will generate a geometry-centered, metric Lambert Azimuthal Equal Area 
+        will generate a geometry-centered, metric Lambert Azimuthal Equal Area
         system in which the buffer will be applied. By default False, i.e. the
         original SRS of the geom will be used.
     split : str, optional
@@ -1875,8 +1875,10 @@ def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
         south_dist = transform(_geom, toSRS=south_srs).Distance(
             point(0, 0, srs=south_srs)
         )
-        if min([north_dist, south_dist]) <= buffer_mtrs: 
-            raise GeoKitGeomError(f"buffered geometry would intersect with North or South Pole.")
+        if min([north_dist, south_dist]) <= buffer_mtrs:
+            raise GeoKitGeomError(
+                f"buffered geometry would intersect with North or South Pole."
+            )
 
         # convert geom to applyBufferInSRS
         _geom = transform(_geom, toSRS=applyBufferInSRS)

--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -1818,9 +1818,7 @@ def divideMultipolygonIntoEasternAndWesternPart(geom, side="both"):
         raise ValueError("side must be 'left', 'right', 'main' or None")
 
 
-def applyBuffer(
-    geom, buffer, applyBufferInSRS=False, split="shift", tol=1e-6, verbose=False
-):
+def applyBuffer(geom, buffer, applyBufferInSRS=False, split="shift"):
     """
     This function applies a buffer to any geom, avoiding edge issues with geoms
     near the SRS bounds. By shifting the geom to a zero longitude, geometry
@@ -1842,110 +1840,73 @@ def applyBuffer(
         be applied in meters in a metric system. By default False, i.e. the
         original SRS of the geom will be used.
         NOTE: 'Lambert_Azimuthal_Equal_Area' or 'Lambert_Conformal_Conic_2SP'
-        projections are not allowed here, use e.g. EPSG:6933 as global metric SRS.
+        projections are not allowed here, use e.g. EPSG:6933 as global metric SRS. #TODO LAEA is allowed now as str
     split : str, optional
         'shift' : shift areas that exceed the antimeridian line to the other end (default)
         'clip' : remove/clip polygon parts that exceed the antimeridian
         'none' : do not split geoms at all that cross the antimeridian
-    tol : int, float, optional
-        Geoms protruding over the +/-90° latitude line will be clipped to 90°
-        plus/minus this tolerance in degrees to avoid geometry issues due to
-        distortions during SRS transformation. By default 1E-6.
-    verbose : boolean, optional
-        If True, additional notifications will be printed when geometry has to
-        be clipped to enable retransformation to initial SRS. By default False.
     """
+    # create copy and extract SRS
+    _srs = geom.GetSpatialReference()
+    _geom = geom.Clone()
+
     if not applyBufferInSRS is False:
-        try:
-            applyBufferInSRS = SRS.loadSRS(applyBufferInSRS)
-        except:
-            raise ValueError(
-                f"applyBufferInSRS {applyBufferInSRS} is not a known SRS to geokit.srs.loadSRS()"
-            )
-        assert not applyBufferInSRS.GetAttrValue("PROJECTION") in [
-            "Lambert_Azimuthal_Equal_Area",
-            "Lambert_Conformal_Conic_2SP",
-        ], (
-            f"SRS projection must not be in: 'Lambert_Azimuthal_Equal_Area', 'Lambert_Conformal_Conic_2SP'"
+        # generate own geom-centered LAEA or load SRS
+        if isinstance(applyBufferInSRS, str) and applyBufferInSRS.upper() == "LAEA":
+            applyBufferInSRS = SRS.centeredLAEA(geom=geom)
+        else:
+            try:
+                applyBufferInSRS = SRS.loadSRS(applyBufferInSRS)
+            except:
+                raise ValueError(
+                    f"applyBufferInSRS {applyBufferInSRS} is not a known SRS to geokit.srs.loadSRS()"
+                )
+        # make sure the poles are far enough to allow the planned buffer
+        buffer_mtrs = buffer * applyBufferInSRS.GetLinearUnits()
+        north_srs = SRS.loadSRS(
+            "+proj=aeqd +lat_0=90 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        )
+        north_dist = transform(geom, toSRS=north_srs).Distance(
+            point(0, 0, srs=north_srs)
+        )
+        south_srs = SRS.loadSRS(
+            "+proj=aeqd +lat_0=-90 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        )
+        south_dist = transform(geom, toSRS=south_srs).Distance(
+            point(0, 0, srs=south_srs)
+        )
+        assert min([north_dist, south_dist]) > buffer_mtrs, (
+            f"buffered geometry would intersect with North or South Pole."
         )
 
-    # first shift the geom to the "center of the world"
-    geom_shftd = shift(
-        geom,
-        lonShift=-geom.Centroid().GetX(),
-        latShift=(
-            -geom.Centroid().GetY() if applyBufferInSRS is False else 0
-        ),  # latitudinal shift would distort latlon-to-metric conversion
+        # convert geom to applyBufferInSRS
+        _geom = transform(geom, toSRS=applyBufferInSRS)
+
+    # apply buffer
+    _geom_buf = _geom.Buffer(buffer)
+    assert _geom_buf.IsValid(), f"buffered geom invalid after applying buffer."
+    # make sure that the buffered geom was not already partially projected by 360° if crossing antimeridian
+    # envelope diffs on either side must be equal to buffer with 1% tolerance
+    assert np.isclose(
+        _geom.GetEnvelope()[0] - _geom_buf.GetEnvelope()[0], buffer, atol=0, rtol=0.01
+    ) and np.isclose(
+        _geom_buf.GetEnvelope()[1] - _geom.GetEnvelope()[1], buffer, atol=0, rtol=0.01
+    ), (
+        f"buffered geom envelope does not match unbuffered geom envelope plus buffers on both sides."
     )
-    if applyBufferInSRS:
-        # transform to applyBufferInSRS srs
-        geom_shftd_epsg = transform(geom_shftd, toSRS=applyBufferInSRS)
-        # apply buffer
-        geom_shftd_buf_epsg = geom_shftd_epsg.Buffer(buffer)
-        assert geom_shftd_buf_epsg.IsValid(), (
-            f"geom in EPSG:{applyBufferInSRS} invalid after buffering."
+
+    # now retransform to original srs if needed
+    if not applyBufferInSRS is False:
+        _geom_buf = transform(_geom_buf, toSRS=_srs)
+
+    # now split if needed
+    if not (split is None or isinstance(split, str) and split.upper() == "NONE"):
+        _geom_buf = fixOutOfBoundsGeoms(_geom_buf, how=split)
+        assert _geom_buf.IsValid(), (
+            f"buffered and re-transformed geom invalid after '{split}' operation"
         )
-        # clip to +/-90° lat "world window" (shrink window by tolerance and transform to EPSG)
-        _worldbox_epsg = transform(
-            polygon(
-                [
-                    (-180 + tol, -90 + tol),
-                    (-180 + tol, 90 - tol),
-                    (180 - tol, 90 - tol),
-                    (180 - tol, -90 + tol),
-                ],
-                srs=4326,
-            ),
-            toSRS=applyBufferInSRS,
-        )
-        _env = geom_shftd_buf_epsg.GetEnvelope()
-        if (
-            _worldbox_epsg.GetEnvelope()[2] < _env[2]
-            or _worldbox_epsg.GetEnvelope()[3] > _env[3]
-        ):
-            # the vertical dimension exceeds the "world window", clip to worldbox to avoid geoms extending over +/-90° lat
-            geom_shftd_buf_epsg = geom_shftd_buf_epsg.Intersection(_worldbox_epsg)
-            _env_new = geom_shftd_buf_epsg.GetEnvelope()
-            if verbose:
-                print(f"NOTE: geometry was clipped vertically.", flush=True)
-            if _env_new[0] < _env[0] or _env_new[1] < _env[1] and not split == "clip":
-                # longitudinal clip, this is not supposed to happen since the geom has been shifted longitudinally!
-                warnings.warn("geometry was clipped horizontally!", Warning)
-        # reconvert to original SRS, still centered on (0,0)
-        geom_shftd_buf = transform(
-            geom_shftd_buf_epsg, toSRS=geom.GetSpatialReference()
-        )
-        # geom is sometimes invalid after transformation, if so try to fix with zero-buffer trick
-        if not geom_shftd_buf.IsValid():
-            geom_shftd_buf = geom_shftd_buf.Buffer(0)
-        assert geom_shftd_buf.IsValid(), (
-            f"buffered geom invalid after re-transformation to initial SRS."
-        )
-    else:
-        # apply buffer in unit of geom SRS
-        geom_shftd_buf = geom_shftd.Buffer(buffer)
-    # shift back to the original centroid location
-    geom_buf = shift(
-        geom_shftd_buf,
-        lonShift=geom.Centroid().GetX(),
-        latShift=(
-            geom.Centroid().GetY() if applyBufferInSRS is False else 0
-        ),  # same as above
-    )
-    assert geom_buf.IsValid(), (
-        f"buffered geom in initial SRS invalid after shifting it back to initial longitude."
-    )
-    if split in ["none", None]:
-        # no splitting of protruding geoms required, return as is
-        return geom_buf
-    elif split == "clip":
-        # clip protruding elements
-        return fixOutOfBoundsGeoms(geom=geom_buf, how="clip")
-    elif split == "shift":
-        # split and shift and re-merge protruding polygon parts
-        return fixOutOfBoundsGeoms(geom=geom_buf, how="shift")
-    else:
-        raise ValueError(f"split argument must be either 'none', 'clip' or 'shift'.")
+
+    return _geom_buf
 
 
 def fixOutOfBoundsGeoms(geom, how="shift"):

--- a/test/test_03_geom.py
+++ b/test/test_03_geom.py
@@ -589,26 +589,36 @@ def test_applyBuffer():
         geom=testpoint_north, buffer=1, applyBufferInSRS=False, split="clip"
     )
     assert np.isclose(buf_north_clip.GetEnvelope(), (-1, +1, 88.9, 90), atol=0).all()
-    # try again with metric system and 50kms buffer
-    buf_north_clip_6933 = geom.applyBuffer(
-        geom=testpoint_north, buffer=50000, applyBufferInSRS=6933, split="clip"
+    # now try again near 90° lat
+    testpoint_north = geom.point(0, 89.9, srs=4326)
+    # first latlon buffer
+    buf_north_clip = geom.applyBuffer(
+        geom=testpoint_north, buffer=1, applyBufferInSRS=False, split="clip"
     )
-    assert np.isclose(buf_north_clip_6933.GetEnvelope()[0], -0.5182083905606406)
-    assert np.isclose(buf_north_clip_6933.GetEnvelope()[1], 0.5182083905606406)
-    assert np.isclose(buf_north_clip_6933.GetEnvelope()[2], 83.33841323028614)
-    assert np.isclose(buf_north_clip_6933.GetEnvelope()[3], 89.99999879797518)
-    # assert buf_north_clip_6933.GetEnvelope() == (
-    #     -0.5182083905606406,
-    #     0.5182083905606406,
-    #     83.33841323028614,
-    #     89.99999879797518,
-    # )
+    assert np.isclose(buf_north_clip.GetEnvelope(), (-1, +1, 88.9, 90), atol=0).all()
+    
+    # try again with metric geom-centric LAEA system and 10 kms (distance to pole is 0.1° lat ergo ca. 11.1 kms)
+    buf = 10000  # 10kms
+    buf_north_clip_LAEA = geom.applyBuffer(
+            geom=testpoint_north, buffer=buf, applyBufferInSRS="laea", split="clip"
+        )
+    assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[0], -63.54229553874337)
+    assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[1], 63.542295538743375)
+    assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[2], 89.81046964488837) # nearly 1° lat diff from center
+    assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[3], 89.98953035070583) # nearly 1° lat diff from center
+    # check area - must be close to 3.14 * 10^8 m² (pi * r^2 with r=10kms)
     assert np.isclose(
-        geom.transform(buf_north_clip_6933, toSRS=6933).Area(),
-        3926325058.480929,
+        geom.transform(buf_north_clip_LAEA, toSRS=6933).Area(),
+        np.pi * buf**2,
         atol=0,
+        rtol=0.001, # allow slightly larger tolerance due to limited number of circle segments
     )
 
+    # now make sure that it fails when the geom would expand over the pole with e.g. 20kms buffer
+    with pytest.raises(geom.GeoKitGeomError):
+        buf_north_clip_LAEA = geom.applyBuffer(
+            geom=testpoint_north, buffer=20000, applyBufferInSRS="laea", split="clip"
+        )
 
 if __name__ == "__main__":
     test_applyBuffer()

--- a/test/test_03_geom.py
+++ b/test/test_03_geom.py
@@ -18,7 +18,7 @@ import pandas as pd
 import pytest
 from osgeo import ogr
 
-from geokit import geom, vector
+from geokit import geom, vector, srs
 
 
 # box
@@ -353,6 +353,15 @@ def test_transform():
     assert t2[0].GetSpatialReference().IsSame(EPSG3035)  # "Transform srs
     assert np.isclose(sum([t.Area() for t in t2]), 83747886418.48529)  # "Transform Area
 
+    # test behavior at antimeridian
+    box = geom.box(-181, -1, -179, 1, srs=4326)
+    boxLAEA = geom.transform(box, toSRS=srs.centeredLAEA(geom=box))
+    # now transform back to 4326 - first the original way
+    box4326 = geom.transform(boxLAEA, toSRS=4326)
+    assert np.isclose(box4326.GetEnvelope(), (-179.0, 179, -1, 1)).all() # wrong but that is expected of PROJ
+    # then the non-shifted way
+    box4326b = geom.transform(boxLAEA, toSRS=4326, revert360degProj=True)
+    assert np.isclose(box4326b.GetEnvelope(), (179, 181, -1, 1)).all() # the right result (note that -181/-179 and 179/181 are the same on a sphere)
 
 def test_extractVerticies():
     # Test polygon

--- a/test/test_03_geom.py
+++ b/test/test_03_geom.py
@@ -358,10 +358,15 @@ def test_transform():
     boxLAEA = geom.transform(box, toSRS=srs.centeredLAEA(geom=box))
     # now transform back to 4326 - first the original way
     box4326 = geom.transform(boxLAEA, toSRS=4326)
-    assert np.isclose(box4326.GetEnvelope(), (-179.0, 179, -1, 1)).all() # wrong but that is expected of PROJ
+    assert np.isclose(
+        box4326.GetEnvelope(), (-179.0, 179, -1, 1)
+    ).all()  # wrong but that is expected of PROJ
     # then the non-shifted way
     box4326b = geom.transform(boxLAEA, toSRS=4326, revert360degProj=True)
-    assert np.isclose(box4326b.GetEnvelope(), (179, 181, -1, 1)).all() # the right result (note that -181/-179 and 179/181 are the same on a sphere)
+    assert (
+        np.isclose(box4326b.GetEnvelope(), (179, 181, -1, 1)).all()
+    )  # the right result (note that -181/-179 and 179/181 are the same on a sphere)
+
 
 def test_extractVerticies():
     # Test polygon
@@ -605,22 +610,26 @@ def test_applyBuffer():
         geom=testpoint_north, buffer=1, applyBufferInSRS=False, split="clip"
     )
     assert np.isclose(buf_north_clip.GetEnvelope(), (-1, +1, 88.9, 90), atol=0).all()
-    
+
     # try again with metric geom-centric LAEA system and 10 kms (distance to pole is 0.1° lat ergo ca. 11.1 kms)
     buf = 10000  # 10kms
     buf_north_clip_LAEA = geom.applyBuffer(
-            geom=testpoint_north, buffer=buf, applyBufferInSRS="laea", split="clip"
-        )
+        geom=testpoint_north, buffer=buf, applyBufferInSRS="laea", split="clip"
+    )
     assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[0], -63.54229553874337)
     assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[1], 63.542295538743375)
-    assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[2], 89.81046964488837) # nearly 1° lat diff from center
-    assert np.isclose(buf_north_clip_LAEA.GetEnvelope()[3], 89.98953035070583) # nearly 1° lat diff from center
+    assert np.isclose(
+        buf_north_clip_LAEA.GetEnvelope()[2], 89.81046964488837
+    )  # nearly 1° lat diff from center
+    assert np.isclose(
+        buf_north_clip_LAEA.GetEnvelope()[3], 89.98953035070583
+    )  # nearly 1° lat diff from center
     # check area - must be close to 3.14 * 10^8 m² (pi * r^2 with r=10kms)
     assert np.isclose(
         geom.transform(buf_north_clip_LAEA, toSRS=6933).Area(),
         np.pi * buf**2,
         atol=0,
-        rtol=0.001, # allow slightly larger tolerance due to limited number of circle segments
+        rtol=0.001,  # allow slightly larger tolerance due to limited number of circle segments
     )
 
     # now make sure that it fails when the geom would expand over the pole with e.g. 20kms buffer
@@ -628,6 +637,7 @@ def test_applyBuffer():
         buf_north_clip_LAEA = geom.applyBuffer(
             geom=testpoint_north, buffer=20000, applyBufferInSRS="laea", split="clip"
         )
+
 
 if __name__ == "__main__":
     test_applyBuffer()


### PR DESCRIPTION
This update allows to handle geometries in a metric (or any suitable) system near the antimeridian and retransform them back into EPSG:4326 lat/lon without breaking the polygons. Incl. test updates.