### PR TITLE
Replace europe_m with with europe_laea

### DIFF
--- a/geokit/core/geom.py
+++ b/geokit/core/geom.py
@@ -763,7 +763,7 @@ def polygonizeMask(mask, bounds=None, srs=None, flat=True, shrink=True):
 # geometry transformer
 
 
-def transform(geoms, toSRS="europe_m", fromSRS=None, segment=None):
+def transform(geoms, toSRS="europe_laea", fromSRS=None, segment=None):
     """Transform a geometry, or a list of geometries, from one SRS to another
 
     Parameters:

--- a/geokit/core/raster.py
+++ b/geokit/core/raster.py
@@ -125,7 +125,7 @@ def createRaster(
     pixelWidth=100,
     pixelHeight=100,
     dtype=None,
-    srs="europe_m",
+    srs="europe_laea",
     compress=True,
     noData=None,
     overwrite: bool = True,

--- a/geokit/core/regionmask.py
+++ b/geokit/core/regionmask.py
@@ -77,7 +77,7 @@ class RegionMask(object):
 
     """
 
-    DEFAULT_SRS = "europe_m"
+    DEFAULT_SRS = "europe_laea"
     DEFAULT_RES = 100
     DEFAULT_PAD = None
 

--- a/geokit/core/srs.py
+++ b/geokit/core/srs.py
@@ -146,7 +146,7 @@ def centeredLAEA(lon=None, lat=None, name="unnamed_m", geom=None):
 # point transformer
 
 
-def xyTransform(*args, fromSRS="latlon", toSRS="europe_m", outputFormat="raw"):
+def xyTransform(*args, fromSRS="latlon", toSRS="europe_laea", outputFormat="raw"):
     """Transform xy points between coordinate systems
 
     Parameters:
@@ -275,17 +275,6 @@ class _SRSCOMMON:
     # basic latitude and longitude
     _europe_laea = osr.SpatialReference()
     _europe_laea.ImportFromEPSG(3035)
-    _europe_m = _europe_laea.Clone()
-
-    @property
-    def europe_m(self):
-        warnings.warn(
-            "SRSCOMMON.europe_m is deprecated and will be removed in a future release. \
-            use SRSCOMMON.europe_laea instead.",
-            DeprecationWarning,
-        )
-
-        return self._europe_m
 
     @property
     def europe_laea(self):

--- a/test/test_03_geom.py
+++ b/test/test_03_geom.py
@@ -1,3 +1,9 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+from osgeo import ogr
+
+from geokit import geom, vector
 from test.helpers import (
     EPSG3035,
     EPSG4326,
@@ -12,13 +18,6 @@ from test.helpers import (
     pointsInAachen4326,
     result,
 )
-
-import matplotlib.pyplot as plt
-import pandas as pd
-import pytest
-from osgeo import ogr
-
-from geokit import geom, vector
 
 
 # box
@@ -348,7 +347,7 @@ def test_transform():
         complexmask, bounds=(6, 45, 11, 50), flat=False, srs=EPSG4326, shrink=None
     )
 
-    t2 = geom.transform(polygons, toSRS="europe_m", segment=0.1)
+    t2 = geom.transform(polygons, toSRS="europe_laea", segment=0.1)
     assert len(t2) == 3  # "Transform Count
     assert t2[0].GetSpatialReference().IsSame(EPSG3035)  # "Transform srs
     assert np.isclose(sum([t.Area() for t in t2]), 83747886418.48529)  # "Transform Area

--- a/test/test_04_raster.py
+++ b/test/test_04_raster.py
@@ -194,29 +194,29 @@ def test_interpolateValues():
     point = (4061794.7, 3094718.4)
 
     v = raster.interpolateValues(
-        CLC_RASTER_PATH, point, pointSRS="europe_m", mode="near"
+        CLC_RASTER_PATH, point, pointSRS="europe_laea", mode="near"
     )
     assert np.isclose(v, 3)
 
     v = raster.interpolateValues(
-        CLC_RASTER_PATH, point, pointSRS="europe_m", mode="linear-spline"
+        CLC_RASTER_PATH, point, pointSRS="europe_laea", mode="linear-spline"
     )
     assert np.isclose(v, 4.572732)  # linear-spline
 
     v = raster.interpolateValues(
-        CLC_RASTER_PATH, point, pointSRS="europe_m", mode="cubic-spline"
+        CLC_RASTER_PATH, point, pointSRS="europe_laea", mode="cubic-spline"
     )
     assert np.isclose(v, 2.4197586642)  # cubic-spline
 
     v = raster.interpolateValues(
-        CLC_RASTER_PATH, point, pointSRS="europe_m", mode="average"
+        CLC_RASTER_PATH, point, pointSRS="europe_laea", mode="average"
     )
     assert np.isclose(v, 9.0612244898)  # average
 
     v = raster.interpolateValues(
         CLC_RASTER_PATH,
         point,
-        pointSRS="europe_m",
+        pointSRS="europe_laea",
         mode="func",
         func=lambda d, xo, yo: d.max(),
     )


### PR DESCRIPTION
This pull request addresses the following issue: https://github.com/FZJ-IEK3-VSA/geokit/issues/227. It does this by replacing all calls to 'europe_m' with calls to 'europe_area'.