### PR TITLE
Make ComputeStatistics optionak

### DIFF
--- a/geokit/_algorithms/combineSimilarRasters.py
+++ b/geokit/_algorithms/combineSimilarRasters.py
@@ -63,7 +63,7 @@ def checkSimilarRasters(
     datasets = _datasets
 
     # get all raster infos
-    infoDataset = [rasterInfo(d) for d in datasets]
+    infoDataset = [rasterInfo(sourceDS=d, compute_statistics=True) for d in datasets]
     # check all relevant variables
     for rInfo in infoDataset[1:]:
         # same srs is required
@@ -182,7 +182,7 @@ def combineSimilarRasters(
     # GET REFERENCE CONTEXT FOR THE OUTPUT RASTER
 
     # determine info for all datasets
-    raster_info_list = [rasterInfo(d) for d in datasets]
+    raster_info_list = [rasterInfo(sourceDS=d, compute_statistics=True) for d in datasets]
 
     # get reference srs - are all the same thanks to checkSimilarRasters
     srs_ref = raster_info_list[0].srs

--- a/geokit/core/raster.py
+++ b/geokit/core/raster.py
@@ -805,8 +805,17 @@ def isFlipped(source):
         return False
 
 
-def rasterInfo(sourceDS: load_raster_input) -> RasterInfo:
+def rasterInfo(sourceDS: load_raster_input, compute_statistics: bool = False) -> RasterInfo:
     """Returns a named tuple containing information relating to the input raster.
+
+    Parameters
+    ----------
+    sourceDS : Anything acceptable by loadRaster()
+        The raster datasource
+    compute_statistics : bool; optional
+        If True, the maximum and minimum value of the raster data are computed.
+        This is computationally expensive for large rasters and repeated calls of
+        this function on the same raster should be avoided.
 
     Returns
     -------
@@ -850,17 +859,21 @@ def rasterInfo(sourceDS: load_raster_input) -> RasterInfo:
     output["scale"] = sourceBand.GetScale()
     output["offset"] = sourceBand.GetOffset()
 
-    try:
-        sourceBand.ComputeStatistics(0)
+    if compute_statistics is True:
+        try:
+            sourceBand.ComputeStatistics(0)
 
-        maximum_value = sourceBand.GetMaximum()
-        minimum_value = sourceBand.GetMinimum()
+            maximum_value = sourceBand.GetMaximum()
+            minimum_value = sourceBand.GetMinimum()
 
-        output["maximum_value"] = maximum_value
-        output["minimum_value"] = minimum_value
-    except:
-        output["maximum_value"] = output["noData"]
-        output["minimum_value"] = output["noData"]
+            output["maximum_value"] = maximum_value
+            output["minimum_value"] = minimum_value
+        except:
+            output["maximum_value"] = output["noData"]
+            output["minimum_value"] = output["noData"]
+    else:
+        output["maximum_value"] = None
+        output["minimum_value"] = None
 
     xSize = sourceBand.XSize
     ySize = sourceBand.YSize
@@ -2509,7 +2522,7 @@ def warp(
     """
     # open source and get info
     source = loadRaster(source)
-    dsInfo = rasterInfo(source)
+    dsInfo = rasterInfo(sourceDS=source, compute_statistics=True)
     if dsInfo.scale != 1.0 or dsInfo.offset != 0.0:
         isAdjusted = True
     else:


### PR DESCRIPTION
This pull request addresses issue https://github.com/FZJ-IEK3-VSA/geokit/issues/286 on GitHub and makes the ComputeStatistics function within rasterInfo optional.

This reduces the interpolation calculation time in example 7 from 40 minutes to 0.7 seconds.