### PR TITLE
284 warp like kwargs

### DIFF
--- a/geokit/core/raster.py
+++ b/geokit/core/raster.py
@@ -2702,8 +2702,8 @@ def warpLike(dataSource: load_raster_input, contextSource: load_raster_input, co
         metadata will be empty or as possibly provided in kwargs. Defaults to False.
     **kwargs
         All kwargs will be passed on to raster.warp()
-        NOTE: If no 'dtype' value as kwargs is given, dtype will be defined 
-        automatically based on the value range, this can be time-consuming 
+        NOTE: If no 'dtype' value as kwargs is given, dtype will be defined
+        automatically based on the value range, this can be time-consuming
         depending on data size. Avoid by specifying dtype explicitly.
     """
     if UTIL.isRaster(dataSource):


### PR DESCRIPTION
This pull request allows to set fill values in raster.warpLike() freely also if no cutline value is provided, else the default of raster.warp() will be set which per default is None, meaning that noData values will be set. Also, the noData value will be set automatically to match the target raster context and noData cell values will be changed to the new noData if need be. The dtype is not specified anymore, allowing to either set a specified dtype as kwarg or not, only in the latter case the dtype will be chosen automatically based on the raster data since it may be time-consuming.