### PR TITLE
"Add hatchling as build backend. Add py.typed to indicate enabled typ…

### DIFF
--- a/geokit/py.typed
+++ b/geokit/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561 - partial type hints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "geokit"
@@ -17,11 +17,18 @@ license = { file = "LICENSE.txt" }
 readme = "README.md"
 
 
-[tool.setuptools.packages.find]
-where = ["."]
+[tool.hatch.build.targets.wheel]
+packages = ["geokit"]
 
-[tool.setuptools.package-data]
-"*" = ["*.*"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/geokit",
+  "/Examples",
+  "/test",
+  "/README.md",
+  "/LICENSE.txt",
+]
 
 #Configuration options
 # https://docs.pytest.org/en/7.1.x/reference/reference.html#configuration-options


### PR DESCRIPTION
This issue incorporates the new build backend from the following GitHub issue: https://github.com/FZJ-IEK3-VSA/geokit/issues/289.

The imports should be changed once the new examples have been merged from the 208_new_examples branch.

However, after this has been merged, a reinstallation of geokit is required.