### PR TITLE
Allow saving of empty vector datasets (#334)

### DIFF
--- a/geokit/vector.py
+++ b/geokit/vector.py
@@ -7,7 +7,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from tempfile import TemporaryDirectory
-from typing import Generator
+from typing import BinaryIO, Generator
 
 import geopandas as gpd
 import numpy as np
@@ -148,6 +148,40 @@ def ogrType(s):
         return ogrType(s[0])
 
     raise ValueError("OGR type could not be determined")
+
+
+# Mapping of geometry names to their OGR wkb type, used to resolve a
+# user-supplied geometry type in createVector()
+_geomNameToWkb = {
+    "POINT": ogr.wkbPoint,
+    "MULTIPOINT": ogr.wkbMultiPoint,
+    "LINE": ogr.wkbLineString,
+    "LINESTRING": ogr.wkbLineString,
+    "MULTILINESTRING": ogr.wkbMultiLineString,
+    "POLYGON": ogr.wkbPolygon,
+    "MULTIPOLYGON": ogr.wkbMultiPolygon,
+    "UNKNOWN": ogr.wkbUnknown,
+}
+
+
+def ogrGeomType(geomType):
+    """Resolve a user-supplied geometry type into an OGR wkb* constant.
+
+    Accepts:
+      * an OGR wkb* integer constant (returned unchanged)
+      * an OGR attribute name, e.g. 'wkbPolygon'
+      * a geometry name, e.g. 'POLYGON', 'point', 'MultiLineString'
+    """
+    if isinstance(geomType, int):
+        return geomType
+    if isinstance(geomType, str):
+        # Allow direct ogr attribute names like 'wkbPolygon'
+        if geomType.startswith("wkb") and hasattr(ogr, geomType):
+            return getattr(ogr, geomType)
+        key = geomType.replace(" ", "").upper()
+        if key in _geomNameToWkb:
+            return _geomNameToWkb[key]
+    raise GeoKitVectorError(f"Could not resolve geomType: {geomType!r}")
 
 
 def filterLayer(layer, geom=None, where=None):
@@ -822,14 +856,16 @@ def extractAndClipFeatures(
         # check validity of input dataframe
         if not "geom" in source.columns:
             raise AttributeError(f"source is given as a pd.DataFrame but has not 'geom' column.")
+        # Nothing to clip: return the (empty) frame with the expected "areaShare" column.
+        # Checked before the dtype check below, which would otherwise index the empty frame
+        # out of bounds.
+        if len(source) == 0:
+            source["areaShare"] = None
+            return source
         if not isinstance(source.geom.iloc[0], ogr.Geometry):
             raise TypeError(
                 f"source is given as a pd.DataFrame but value in 'geom' column is not of type osgeo.ogr.Geometry."
             )
-        # return empty dataframe with empty expected "areaShare" column if no geometries contained since vector cannot be created without geometries
-        if len(source) == 0:
-            source["areaShare"] = None
-            return source
         # generate a vector from source dataframe
         source = createVector(source)
     elif isinstance(source, str) or isinstance(source, pathlib.Path):
@@ -945,17 +981,17 @@ def extractAndClipFeatures(
 ####################################################################
 # Create a vector
 def createVector(
-    # geoms: ogr.Geometry | list[ogr.Geometry | gdal.Dataset | str] | pd.DataFrame | np.ndarray | str | gdal.Dataset,
-    geoms,
+    geoms: ogr.Geometry | str | pd.Series | pd.DataFrame | np.ndarray | list[ogr.Geometry | str],
     output: str | None = None,
-    srs=None,
+    srs: srs_input | None = None,
     driverName: str = "ESRI Shapefile",
     layerName: str = "default",
-    fieldVals=None,
-    fieldDef=None,
-    checkAllGeoms=False,
+    fieldVals: dict | pd.DataFrame | None = None,
+    fieldDef: dict | str | type | None = None,
+    checkAllGeoms: bool = False,
     overwrite: bool = True,
-):
+    geomType: int | str | None = None,
+) -> gdal.Dataset | str:
     """
     Create a vector on disk from geometries or a DataFrame with 'geom' column.
 
@@ -1022,10 +1058,20 @@ def createVector(
         Determines whether the preexisting files should be overwritten
         * Only used when output is not None
 
+    geomType : int or str; optional
+        Explicitly set the geometry type of the output layer
+        * Accepts an OGR wkb* constant (e.g. ogr.wkbPolygon), an OGR attribute
+          name (e.g. 'wkbPolygon') or a geometry name (e.g. 'POLYGON')
+        * If None (default), the geometry type is inferred from the input
+          geometries. When the input is empty, it defaults to 'POINT'.
+        * If given, it overrides the inferred type for both empty and
+          non-empty inputs. The caller is responsible for ensuring the chosen
+          type is compatible with the geometries written.
+
     Returns
     -------
     * If 'output' is None: gdal.Dataset
-    * If 'output' is given: None
+    * If 'output' is given: str (the output path)
     """
     if srs:
         srs = SRS.loadSRS(srs)
@@ -1048,70 +1094,82 @@ def createVector(
         geoms = geoms.geom.values
         fieldVals.drop("geom", inplace=True, axis=1)
 
-    if len(geoms) == 0:
-        raise GeoKitVectorError("Empty geometry list given")
+    # Resolve an explicitly given geometry type (overrides the inferred type)
+    if geomType is not None:
+        geomType = ogrGeomType(geomType)
 
-    # Test if the first geometry is an ogr-Geometry type
-    if isinstance(geoms[0], ogr.Geometry):
-        #  (Assume all geometries in the array have the same type)
-        geomSRS = geoms[0].GetSpatialReference()
-        if checkAllGeoms:
-            # check if all other geoms have the same SRS
-            assert all([geomSRS.IsSame(g.GetSpatialReference()) for g in geoms]), (
-                f"Not all geoms have the same SRS, srs of first geom: {geomSRS}"
-            )
-        # Set up some variables for the upcoming loop
-        doTransform = False
-        setSRS = False
+    # An empty geometry list is allowed: a valid, empty dataset is written so
+    # that filtered-to-empty results can still serve as a flag/input downstream.
+    # The per-geometry type/SRS inference below is skipped in that case; 'srs'
+    # stays as given and the geometry type defaults to POINT (see below) unless
+    # explicitly set via 'geomType'.
+    if len(geoms) > 0:
+        # Test if the first geometry is an ogr-Geometry type
+        if isinstance(geoms[0], ogr.Geometry):
+            #  (Assume all geometries in the array have the same type)
+            geomSRS = geoms[0].GetSpatialReference()
+            if checkAllGeoms:
+                # check if all other geoms have the same SRS
+                assert all([geomSRS.IsSame(g.GetSpatialReference()) for g in geoms]), (
+                    f"Not all geoms have the same SRS, srs of first geom: {geomSRS}"
+                )
+            # Set up some variables for the upcoming loop
+            doTransform = False
+            setSRS = False
 
-        if srs and geomSRS and not srs.IsSame(geomSRS):  # Test if a transformation is needed
-            trx = osr.CoordinateTransformation(geomSRS, srs)
-            doTransform = True
-        # Test if an srs was NOT given, but the incoming geometries have an SRS already
-        elif srs is None and geomSRS:
-            srs = geomSRS
-        # Test if an srs WAS given, but the incoming geometries do NOT have an srs already
-        elif srs and geomSRS is None:
-            # In which case, assume the geometries are meant to have the given srs
-            setSRS = True
+            if srs and geomSRS and not srs.IsSame(geomSRS):  # Test if a transformation is needed
+                trx = osr.CoordinateTransformation(geomSRS, srs)
+                doTransform = True
+            # Test if an srs was NOT given, but the incoming geometries have an SRS already
+            elif srs is None and geomSRS:
+                srs = geomSRS
+            # Test if an srs WAS given, but the incoming geometries do NOT have an srs already
+            elif srs and geomSRS is None:
+                # In which case, assume the geometries are meant to have the given srs
+                setSRS = True
 
-        # Create geoms
-        for i in range(len(geoms)):
-            # clone just in case the geometry is tethered outside of function
-            finalGeoms.append(geoms[i].Clone())
-            if doTransform:
-                finalGeoms[i].Transform(trx)  # Do transform if necessary
-            if setSRS:
-                finalGeoms[i].AssignSpatialReference(srs)  # Set srs if necessary
+            # Create geoms
+            for i in range(len(geoms)):
+                # clone just in case the geometry is tethered outside of function
+                finalGeoms.append(geoms[i].Clone())
+                if doTransform:
+                    finalGeoms[i].Transform(trx)  # Do transform if necessary
+                if setSRS:
+                    finalGeoms[i].AssignSpatialReference(srs)  # Set srs if necessary
 
-    # Otherwise, the geometry array should contain only WKT strings
-    elif isinstance(geoms[0], str):
-        if srs is None:
-            raise ValueError("srs must be given when passing wkt strings")
+        # Otherwise, the geometry array should contain only WKT strings
+        elif isinstance(geoms[0], str):
+            if srs is None:
+                raise ValueError("srs must be given when passing wkt strings")
 
-        # Create geoms
-        finalGeoms = [GEOM.convertWKT(wkt, srs) for wkt in geoms]
+            # Create geoms
+            finalGeoms = [GEOM.convertWKT(wkt, srs) for wkt in geoms]
 
-    else:
-        raise ValueError("Geometry inputs must be ogr.Geometry objects or WKT strings")
+        else:
+            raise ValueError("Geometry inputs must be ogr.Geometry objects or WKT strings")
 
     geoms = finalGeoms  # Overwrite geoms array with the conditioned finalGeoms
 
-    # Determine geometry types
-    types = set()
-    for g in geoms:
-        # Get a set of all geometry type-names (POINT, POLYGON, etc...)
-        types.add(g.GetGeometryName())
+    # Determine the geometry type of the output layer
+    if geomType is None:
+        if len(geoms) == 0:
+            # No geometries to infer from -> default to POINT
+            geomType = ogr.wkbPoint
+        else:
+            # Get a set of all geometry type-names (POINT, POLYGON, etc...)
+            types = set()
+            for g in geoms:
+                types.add(g.GetGeometryName())
 
-    if types.issubset({"POINT", "MULTIPOINT"}):
-        geomType = ogr.wkbPoint
-    elif types.issubset({"LINESTRING", "MULTILINESTRING"}):
-        geomType = ogr.wkbLineString
-    elif types.issubset({"POLYGON", "MULTIPOLYGON"}):
-        geomType = ogr.wkbPolygon
-    else:
-        # geomType = ogr.wkbGeometryCollection
-        raise RuntimeError("Could not determine output shape's geometry type")
+            if types.issubset({"POINT", "MULTIPOINT"}):
+                geomType = ogr.wkbPoint
+            elif types.issubset({"LINESTRING", "MULTILINESTRING"}):
+                geomType = ogr.wkbLineString
+            elif types.issubset({"POLYGON", "MULTIPOLYGON"}):
+                geomType = ogr.wkbPolygon
+            else:
+                # geomType = ogr.wkbGeometryCollection
+                raise RuntimeError("Could not determine output shape's geometry type")
 
     # Create a driver and datasource
     # driver = gdal.GetDriverByName("ESRI Shapefile")
@@ -1251,7 +1309,13 @@ def createVector(
         raise e
 
 
-def createGeoJson(geoms, output=None, srs=4326, topo=False, fill=""):
+def createGeoJson(
+    geoms: ogr.Geometry | pd.Series | pd.DataFrame | Iterable[ogr.Geometry],
+    output: str | BinaryIO | None = None,
+    srs: srs_input | None = 4326,
+    topo: bool = False,
+    fill: str = "",
+) -> str | None:
     """Convert a set of geometries to a geoJSON object."""
     if srs:
         srs = SRS.loadSRS(srs)
@@ -1281,11 +1345,9 @@ def createGeoJson(geoms, output=None, srs=4326, topo=False, fill=""):
         data = None
         index = list(range(len(finalGeoms)))
 
-    if len(finalGeoms) == 0:
-        raise GeoKitVectorError("Empty geometry list given")
-
-    # Transform?
-    if not srs is None:
+    # Transform? (skipped for empty input, which writes a valid empty
+    # FeatureCollection so filtered-to-empty results can still be saved)
+    if not srs is None and len(finalGeoms) > 0:
         finalGeoms = GEOM.transform(finalGeoms, toSRS=srs)
 
     # Make JSON object

--- a/test/test_05_vector.py
+++ b/test/test_05_vector.py
@@ -1,5 +1,6 @@
 from functools import reduce
 from os.path import dirname, join
+import json
 import pathlib
 import geopandas as gpd
 import pandas as pd
@@ -164,6 +165,15 @@ def test_extractAndClipFeatures():
     assert all(np.isclose(clipped.areaShare.values, np.array([0.827164, 1.0])))
     assert all(np.isclose(clipped.testAttr.values, np.array([82.716413, 100.0])))
 
+    # An empty source DataFrame must be handled gracefully (previously raised
+    # IndexError): return the empty frame with the expected 'areaShare' column
+    # and the input attribute columns preserved.
+    empty_source = pd.DataFrame(columns=["geom", "testAttr"])
+    clipped_empty = vector.extractAndClipFeatures(source=empty_source, geom=box)
+    assert len(clipped_empty) == 0
+    assert "areaShare" in clipped_empty.columns
+    assert "testAttr" in clipped_empty.columns
+
 
 def test_createVector(tmpdir):
     # Create shape file
@@ -297,6 +307,60 @@ def test_createVector(tmpdir):
     assert all(test_equal_gpkg)
 
     assert all([g.IsValid() for g in vec_gpkg_lyr_1_disk["geom"]])
+
+
+def test_createVector_empty(tmpdir):
+    # Filtering large/parallelized geodata may legitimately yield empty datasets.
+    # createVector must be able to save these (like geopandas) instead of raising.
+    empty_df = pd.DataFrame(columns=["geom", "attributeA", "attributeB"])
+
+    # ESRI Shapefile, default geometry type -> POINT, schema preserved
+    out_shp = tmpdir.join("empty.shp").__str__()
+    vector.createVector(empty_df, output=out_shp, srs=EPSG4326)
+    ds = ogr.Open(out_shp)
+    ly = ds.GetLayer()
+    assert ly.GetFeatureCount() == 0
+    assert ogr.GeometryTypeToName(ly.GetGeomType()) == "Point"
+    assert ly.GetSpatialRef().IsSame(EPSG4326)
+    fieldNames = [ly.GetLayerDefn().GetFieldDefn(i).GetName() for i in range(ly.GetLayerDefn().GetFieldCount())]
+    assert fieldNames == ["attributeA", "attributeB"]  # attribute schema preserved
+    ds = None
+
+    # explicit geomType overrides the default for empty input
+    out_poly = tmpdir.join("empty_poly.shp").__str__()
+    vector.createVector(empty_df, output=out_poly, srs=EPSG4326, geomType="POLYGON")
+    ds = ogr.Open(out_poly)
+    assert ogr.GeometryTypeToName(ds.GetLayer().GetGeomType()) == "Polygon"
+    ds = None
+
+    # GeoPackage, empty
+    out_gpkg = tmpdir.join("empty.gpkg").__str__()
+    vector.createVector(empty_df, output=out_gpkg, srs=EPSG4326, driverName="GPKG", layerName="flag")
+    ds = ogr.Open(out_gpkg)
+    assert ds.GetLayer().GetFeatureCount() == 0
+    ds = None
+
+    # in-memory empty dataset
+    memVec = vector.createVector(empty_df, srs=EPSG4326)
+    assert memVec.GetLayer().GetFeatureCount() == 0
+
+    # geomType override also applies to non-empty input (here forcing the layer type)
+    out_forced = tmpdir.join("forced.gpkg").__str__()
+    vector.createVector([GEOM], output=out_forced, srs=EPSG4326, driverName="GPKG", geomType="MULTIPOLYGON")
+    ds = ogr.Open(out_forced)
+    assert ogr.GeometryTypeToName(ds.GetLayer().GetGeomType()) == "Multi Polygon"
+    ds = None
+
+
+def test_createGeoJson_empty():
+    # An empty dataset must produce a valid, empty FeatureCollection
+    empty_df = pd.DataFrame(columns=["geom", "attributeA", "attributeB"])
+
+    geojson = vector.createGeoJson(empty_df)
+    assert json.loads(geojson) == {"type": "FeatureCollection", "features": []}
+
+    # empty list input as well
+    assert json.loads(vector.createGeoJson([])) == {"type": "FeatureCollection", "features": []}
 
 
 def test_mutateVector():


### PR DESCRIPTION
Closes #334.

When filtering large/parallelized geodata, results can legitimately be empty. geopandas saves such datasets, but GeoKit rejected them with `GeoKitVectorError("Empty geometry list given")`. This PR makes the relevant creation functions accept empty input, matching geopandas behavior.

## Changes

**`createVector`**
- Removed the empty-list guard. The `geoms[0]`-based geometry-type/SRS inference is now skipped for empty input.
- Empty input writes a valid, empty dataset with the **attribute schema preserved** (field definitions still written, feature loop is a no-op, `srs` kept as given).
- New `geomType=` parameter (accepts an OGR `wkb*` constant, an OGR attribute name like `'wkbPolygon'`, or a geometry name like `'POLYGON'`). When `None` (default) the type is inferred from the geometries; **empty input defaults to `POINT`**. When supplied, it overrides the inferred type for both empty and non-empty input.

**`createGeoJson`**
- Removed the empty-list guard and skip `GEOM.transform` on empty input (it indexes `geoms[0]` and would `IndexError`). Now emits a valid empty `FeatureCollection`.

**`extractAndClipFeatures`** (follow-up)
- Fixed a latent bug: an empty source DataFrame raised `IndexError` at the `source.geom.iloc[0]` dtype-check *before* the existing empty-handling guard was reachable. The empty check now runs first, so empty sources return the empty frame with the expected `areaShare` column and input attribute columns preserved.

**Misc**
- Added proper type hints to `createVector` and `createGeoJson`.
- Fixed the stale `createVector` return docstring (it returns the output path, not `None`, when `output` is given).

## Tests
- `test_createVector_empty`: empty → Shapefile (default Point), GPKG, in-memory; attribute schema preserved; `geomType` override for empty and non-empty input.
- `test_createGeoJson_empty`: empty DataFrame and empty list both yield a valid empty `FeatureCollection`.
- `test_extractAndClipFeatures`: added an empty-source case.

Full suite: **285 passed**; ruff lint + format clean.

## Design notes
- For an empty dataset the geometry type is genuinely unknown; default is `POINT` (cleanest shapefile round-trip), overridable via `geomType=`.
- With no geometries the SRS cannot be inferred, so an empty file has no `.prj`/CRS unless the caller passes `srs` — succeeds silently, consistent with geopandas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)